### PR TITLE
fix: stabilize pdf extraction in electron main process

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3512,3 +3512,24 @@
 - **Rationale**: A personal profile gives the app a user-centered memory layer; combining manual edits with library-derived signals makes the profile both editable and grounded in actual reading behavior
 - **Test Design**: Validate profile snapshot aggregation, manual edits, summary generation, and empty-library guardrails through a focused service test, then run main and renderer builds
 - **Validation**: `npx vitest run tests/integration/user-profile.test.ts`, `npm run build:main`, `npm run build:renderer`
+
+### Debugging: Add pdf-parse Module Shape Logging for Paper Text Extraction
+
+- **Scope**: `src/main/services/pdf-extractor.service.ts`
+- **Changes**:
+  - Added targeted diagnostic logging when the dynamically imported `pdf-parse` module does not expose a callable `PDFParse` constructor
+  - Logged top-level export keys plus the default export shape to capture development vs. production module-resolution differences during paper import
+- **Rationale**: A local-only `PDFParse is not a constructor` failure needs direct runtime evidence from the Electron main process before changing the import strategy
+- **Test Design**: Rebuild the main process and reproduce paper import once to inspect the logged module shape from the real Electron execution path
+- **Validation**: Pending reproduction in `npm run dev`
+
+### Fix: Externalize pdf-parse and Harden Constructor Resolution
+
+- **Scope**: `scripts/build-main.mjs`, `src/main/services/pdf-extractor.service.ts`, `tests/integration/pdf-extractor.test.ts`
+- **Changes**:
+  - Marked `pdf-parse` as external in the main-process build so Electron loads the package directly instead of relying on an esbuild-generated namespace wrapper
+  - Added a small constructor resolver that accepts both named and nested default export shapes and throws a clear error for unsupported module shapes
+  - Added focused tests covering the supported `pdf-parse` module shapes
+- **Rationale**: The paper import failure was caused by `pdf-parse` being bundled into the Electron main-process output, where its `PDFParse` export name existed but its bound value became `undefined`
+- **Test Design**: Run the focused extractor test first, then rebuild the main process so the externalization takes effect in the generated bundle
+- **Validation**: Pending `npx vitest run tests/integration/pdf-extractor.test.ts` and `npm run build:main`

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -68,6 +68,8 @@ const external = [
   // Transformers.js + ONNX Runtime — must stay external for WASM/native loading
   '@huggingface/transformers',
   'onnxruntime-node',
+  // pdf-parse relies on ESM/conditional exports that break when bundled into the main process
+  'pdf-parse',
   // SSH2 + cpu-features: contain .node native addons
   'ssh2',
   'cpu-features',

--- a/src/main/services/pdf-extractor.service.ts
+++ b/src/main/services/pdf-extractor.service.ts
@@ -21,11 +21,46 @@ interface PdfParseResult {
   info: Record<string, unknown>;
 }
 
+type PdfParseConstructor = new (options: { data: Buffer }) => {
+  getText(): Promise<TextResult>;
+  getInfo(): Promise<InfoResult>;
+};
+
+function isPdfParseConstructor(value: unknown): value is PdfParseConstructor {
+  return typeof value === 'function';
+}
+
+export function resolvePdfParseConstructor(moduleValue: unknown): PdfParseConstructor {
+  const candidates = [
+    (moduleValue as { PDFParse?: unknown })?.PDFParse,
+    (moduleValue as { default?: { PDFParse?: unknown } })?.default?.PDFParse,
+    (moduleValue as { default?: unknown })?.default,
+  ];
+
+  for (const candidate of candidates) {
+    if (isPdfParseConstructor(candidate)) {
+      return candidate;
+    }
+  }
+
+  const moduleRecord =
+    moduleValue && typeof moduleValue === 'object' ? (moduleValue as Record<string, unknown>) : {};
+  const defaultRecord =
+    moduleRecord.default && typeof moduleRecord.default === 'object'
+      ? (moduleRecord.default as Record<string, unknown>)
+      : {};
+
+  throw new Error(
+    `Unable to resolve pdf-parse PDFParse constructor (keys: ${Object.keys(moduleRecord).join(
+      ', ',
+    )}, default keys: ${Object.keys(defaultRecord).join(', ')})`,
+  );
+}
+
 // Dynamic import for pdf-parse (ESM compatibility)
 async function parsePdf(buffer: Buffer, _options?: { max?: number }): Promise<PdfParseResult> {
-  // pdf-parse v2 uses a class-based API
   const pdfParseModule = await import('pdf-parse');
-  const PDFParse = pdfParseModule.PDFParse;
+  const PDFParse = resolvePdfParseConstructor(pdfParseModule);
   const parser = new PDFParse({ data: buffer });
 
   const textResult: TextResult = await parser.getText();

--- a/tests/integration/pdf-extractor.test.ts
+++ b/tests/integration/pdf-extractor.test.ts
@@ -5,6 +5,7 @@ import {
   extractTextFromPdfUrl,
   extractFromArxiv,
   getPaperExcerpt,
+  resolvePdfParseConstructor,
 } from '../../src/main/services/pdf-extractor.service';
 
 describe('pdf-extractor service', () => {
@@ -39,6 +40,30 @@ describe('pdf-extractor service', () => {
     it('generates correct PDF URL', () => {
       const result = getArxivPdfUrl('2301.07041');
       expect(result).toBe('https://arxiv.org/pdf/2301.07041');
+    });
+  });
+
+  describe('resolvePdfParseConstructor', () => {
+    it('accepts the standard named PDFParse export', () => {
+      class FakeParser {}
+
+      const result = resolvePdfParseConstructor({ PDFParse: FakeParser });
+
+      expect(result).toBe(FakeParser);
+    });
+
+    it('accepts a nested default PDFParse export', () => {
+      class FakeParser {}
+
+      const result = resolvePdfParseConstructor({ default: { PDFParse: FakeParser } });
+
+      expect(result).toBe(FakeParser);
+    });
+
+    it('throws a clear error when no constructor is exposed', () => {
+      expect(() => resolvePdfParseConstructor({ PDFParse: undefined })).toThrow(
+        /Unable to resolve pdf-parse PDFParse constructor/,
+      );
     });
   });
 


### PR DESCRIPTION
## 概要

本次 PR 主要修复 Electron 主进程中的 PDF 提取稳定性问题，并补充对应的集成测试覆盖，避免在特定情况下出现提取失败或行为不一致。

## 改动内容

- 加固 PDF 提取服务的处理逻辑，提升在 Electron 主进程中的稳定性
- 调整主进程构建脚本中的相关处理，确保提取链路行为一致
- 新增/更新 PDF 提取相关集成测试，覆盖本次修复的回归场景
- 更新本次开发会话对应的 changelog 记录

## 影响范围

- PDF 提取主流程
- 主进程构建流程
- PDF 提取回归测试

## 验证说明

- 已补充/更新 `tests/integration/pdf-extractor.test.ts` 中的相关测试用例

## 备注

- 本地 `package-lock.json` 存在 npm 11 触发的 lockfile 元数据重写，但与本次修复无关，因此未纳入本 PR
