### PR TITLE
fix: chat shows full conversation history

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,17 @@
 # Changelog
 
-<<<<<<< HEAD
-
 ## 0.0.4 (2026-03-23)
+
+### fix: Chat only showing most recent Q&A instead of full history
+
+**Summary**: Fixed paper reader chat displaying only the latest round of conversation. Previous messages were lost when the agent streamed new responses because `agentMessages` replaced `historicMessages` entirely.
+
+**Changes**:
+
+1. Combined `historicMessages` with `agentMessages` using `useMemo` with msgId deduplication
+2. Full conversation history now persists while new stream messages append
+
+**Test validation**: Passed `npm run lint` and `npm run test`.
 
 ### test: Skip Windows-specific tests on macOS and Linux
 

--- a/src/renderer/pages/papers/reader/page.tsx
+++ b/src/renderer/pages/papers/reader/page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef, useLayoutEffect } from 'react';
+import { useEffect, useState, useCallback, useRef, useLayoutEffect, useMemo } from 'react';
 import { useParams, useNavigate, useLocation, useSearchParams, useBlocker } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import i18n from 'i18next';
@@ -450,8 +450,14 @@ export function ReaderPage() {
     }
   }, [agentStatus]);
 
-  // Use live stream messages if available, otherwise fall back to historic messages
-  const streamBased = agentMessages.length > 0 ? agentMessages : historicMessages;
+  // Combine historic messages with live stream messages so the full conversation is visible.
+  // Deduplicate by msgId in case historic and stream overlap during recovery.
+  const streamBased = useMemo(() => {
+    if (agentMessages.length === 0) return historicMessages;
+    const historicIds = new Set(historicMessages.map((m: any) => m.msgId));
+    const newStreamMsgs = agentMessages.filter((m: any) => !historicIds.has(m.msgId));
+    return [...historicMessages, ...newStreamMsgs];
+  }, [historicMessages, agentMessages]);
   // Merge local user messages with stream/historic messages chronologically.
   // Local user messages have createdAt timestamps; stream messages also have createdAt.
   // This ensures multi-turn conversations display in correct order:


### PR DESCRIPTION
## Summary
- Fix paper reader chat only displaying the latest Q&A round
- Merge `historicMessages` with live `agentMessages` using `useMemo` with msgId deduplication
- Full conversation history now persists while new stream messages append

## Test plan
- [x] `npm run lint` passes
- [x] `npm run test` — 626 passed, 50 skipped
- [ ] Manual: open a paper chat, send multiple messages — all rounds should remain visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)